### PR TITLE
(#3) Manage dependencies

### DIFF
--- a/.plugin.yaml
+++ b/.plugin.yaml
@@ -1,0 +1,3 @@
+---
+mcollective_agent_nettest::gem_dependencies:
+  net-ping: "2.0.6"

--- a/README.md
+++ b/README.md
@@ -6,31 +6,8 @@ I often find myself logging onto boxes to ping different sites to diagnose local
 
 ## Installation
 
-Install the `Net::Ping` RubyGem on all your agent nodes:
-
-**NOTE:** To install this gem you need to have a c++ compiler on your system
-
-```yaml
-mcollective_agent_nettest::gem_dependencies:
-  "net-ping": "2.0.2"
-```
-
-Add the agent and client:
-
-```yaml
-mcollective::plugin_classes:
-  - mcollective_agent_nettest
-```
-
-### Archlinux
-
-On Archlinux machines the following Hiera data will install the dependencies using native packages and you do not need compilers:
-
-```yaml
-mcollective_agent_nettest::manage_gem_dependencies: false
-mcollective_agent_nettest::package_dependencies:
-  ruby-net-ping: present
-```
+This module depends on the `Net::Ping` Ruby gem which requires a C++ compiler
+to build.
 
 ## Usage
 

--- a/puppet/data/os/Archlinux.yaml
+++ b/puppet/data/os/Archlinux.yaml
@@ -1,0 +1,4 @@
+---
+mcollective_agent_nettest::manage_gem_dependencies: false
+mcollective_agent_nettest::package_dependencies:
+  ruby-net-ping: "present"

--- a/puppet/data/os/FreeBSD.yaml
+++ b/puppet/data/os/FreeBSD.yaml
@@ -1,0 +1,4 @@
+---
+mcollective_agent_nettest::manage_gem_dependencies: false
+mcollective_agent_nettest::package_dependencies:
+  rubygem-net-ping: "present"

--- a/puppet/hiera.yaml
+++ b/puppet/hiera.yaml
@@ -1,0 +1,14 @@
+---
+version: 5
+
+defaults:
+  datadir: "data"
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "plugin"
+    path: "plugin.yaml"
+  - name: "os-specific"
+    path: "os/%{facts.os.family}.yaml"
+  - name: "defaults"
+    path: "defaults.yaml"


### PR DESCRIPTION
I am lacking a way for easily testing this with a r10k managed repository, so just double-checked that the content of the module generated by `mco plugin package --vendor acme` has the expected Hiera files.
